### PR TITLE
feature: add ability to skip health checks and immediately reboot gateway

### DIFF
--- a/tmo-monitor.py
+++ b/tmo-monitor.py
@@ -63,27 +63,29 @@ parser.add_argument('username', type=str, help='the username. should be admin')
 parser.add_argument('password', type=str, help='the administrative password')
 parser.add_argument('-I', '--interface', type=str, help='the network interface to use for ping')
 parser.add_argument('-H', '--ping-host', type=str, default='google.com', help='the host to ping')
+parser.add_argument('-R', '--reboot', action="store_true", help='skip health checks and immediately reboot gateway')
 args = parser.parse_args()
 
-reboot_requested = False
+reboot_requested = args.reboot
 
-signal_request = requests.get('http://192.168.12.1/fastmile_radio_status_web_app.cgi')
-signal_request.raise_for_status()
-signal_info = signal_request.json()
-band_5g = signal_info['cell_5G_stats_cfg'][0]['stat']['Band']
-if band_5g != 'n41':
-  print('Not on n41. Reboot requested.')
-  reboot_requested = True
-else:
-  print('Camping on n41. Not rebooting.')
+if not reboot_requested:
+  signal_request = requests.get('http://192.168.12.1/fastmile_radio_status_web_app.cgi')
+  signal_request.raise_for_status()
+  signal_info = signal_request.json()
+  band_5g = signal_info['cell_5G_stats_cfg'][0]['stat']['Band']
+  if band_5g != 'n41':
+    print('Not on n41. Reboot requested.')
+    reboot_requested = True
+  else:
+    print('Camping on n41. Not rebooting.')
 
-ping_cmd = ['ping']
-if args.interface:
-  ping_cmd.append('-I')
-  ping_cmd.append(args.interface)
-ping_cmd.append('-c')
-ping_cmd.append('1')
-ping_cmd.append(args.ping_host)
+  ping_cmd = ['ping']
+  if args.interface:
+    ping_cmd.append('-I')
+    ping_cmd.append(args.interface)
+  ping_cmd.append('-c')
+  ping_cmd.append('1')
+  ping_cmd.append(args.ping_host)
 
 if not reboot_requested and subprocess.call(ping_cmd) != 0:
   print('Could not ping ' + args.ping_host + '. reboot requested')


### PR DESCRIPTION
Add `--reboot` argument to force a reboot of the gateway and skip the health checks (for use in, say, a nightly cronjob to reboot the gateway regardless of connection status).