### PR TITLE
overhaul the way credentials are managed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# ignore credentials file
+credentials.json

--- a/README.md
+++ b/README.md
@@ -17,32 +17,49 @@ Windows is not currently supported, but should work well with *nix OSes.
 
 ## Usage
 ```
-usage: tmo-monitor.py [-h] [-I INTERFACE] [-H PING_HOST] username password
+usage: tmo-monitor.py [-h] [-u USERNAME] [-p PASSWORD] [-I INTERFACE] [-H PING_HOST] [-g] [-f CREDENTIALS_FILE]
+                      [-R]
 
 Check T-Mobile Home Internet 5g band and connectivity and reboot if necessary
 
-positional arguments:
-  username              the username. should be admin
-  password              the administrative password
-
 optional arguments:
   -h, --help            show this help message and exit
+  -u USERNAME, --username USERNAME
+                        the administrative username (defaults to "admin")
+  -p PASSWORD, --password PASSWORD
+                        the administrative password (will be prompted if not passed as argument)
   -I INTERFACE, --interface INTERFACE
                         the network interface to use for ping
   -H PING_HOST, --ping-host PING_HOST
+                        the host to ping (defaults to google.com)
+  -g, --generate-credentials
+                        generate credentials and exit (saved as credentials.json unless used in combination with
+                        -f)
+  -f CREDENTIALS_FILE, --credentials-file CREDENTIALS_FILE
+                        file from which to save/load saved credentials
   -R, --reboot          skip health checks and immediately reboot gateway
 ```
 
 ## Options
 **Interface:** `--interface`
-    Can be used to specify the network interface used by the ping command. Useful if T-Mobile Home Internet is not your default network interface: e.g., this is running on a dual WAN router.
+
+  Can be used to specify the network interface used by the ping command. Useful if T-Mobile Home Internet is not your default network interface: e.g., this is running on a dual WAN router.
     
-**Ping Host** `--ping-host`
-    Defaults to `google.com` - override if you'd like to ping an alternate host to determine internet connectivity.
+**Ping Host:** `--ping-host`
+
+  Defaults to `google.com` - override if you'd like to ping an alternate host to determine internet connectivity.
     
-    
-**Reboot** `--reboot`
-    Skip health checks and immediately reboot gateway.
+**Reboot:** `--reboot`
+
+  Skip health checks and immediately reboot gateway.
+
+**Generate Credentials File:** `--generate-credentials`
+
+  Generate credentials and save to file (defaults to `credentials.json`, but can be specified with `--credentials-file <filename.json>`)
+
+**Load Credentials From File:** `--credentials-file <filename.json>`
+
+  Load saved credentials from file (**alternate use**: specifies file to which credentials should be saved if used in combination with `--generate-credentials`)
 
 ## Known Issues
 Windows OS ping implementation is not supported.

--- a/tmo-monitor.py
+++ b/tmo-monitor.py
@@ -7,92 +7,156 @@ import hashlib
 from base64 import b64encode
 import secrets
 import argparse
+import getpass
+import json
 
-def reboot():
-  nonce_request = requests.get('http://192.168.12.1/login_web_app.cgi?nonce')
-  nonce_request.raise_for_status()
-  nonce_response = nonce_request.json()
-  
-  s = sha256(args.username, args.password)
-  r = sha256url(s, nonce_response['nonce'])
-  login_request_body = {}
-  login_request_body['userhash'] = sha256url(args.username, nonce_response['nonce'])
-  login_request_body['RandomKeyhash'] = sha256url(nonce_response['randomKey'], nonce_response['nonce'])
-  login_request_body['response'] = r
-  login_request_body['nonce'] = base64url_escape(nonce_response['nonce'])
-  
-  l = b64encode(secrets.token_bytes(16)).decode('utf-8')
-  c = b64encode(secrets.token_bytes(16)).decode('utf-8')
-  login_request_body['enckey'] = base64url_escape(l)
-  login_request_body['enciv'] = base64url_escape(c)
-  
-  login_request = requests.post('http://192.168.12.1/login_web_app.cgi', data=login_request_body)
-  login_request.raise_for_status()
-  jar = requests.cookies.RequestsCookieJar()
-  jar.set('sid', login_request.cookies['sid'], domain='192.168.12.1', path='/')
-  jar.set('lsid', login_request.cookies['lsid'], domain='192.168.12.1', path='/')
-  login_response = login_request.json()
-  csrf_token = login_response['token']
-  
-  reboot_request = requests.post('http://192.168.12.1/reboot_web_app.cgi', data={'csrf_token': csrf_token}, cookies=jar)
-  reboot_request.raise_for_status()
-
-def base64url_escape(b64):
-  out = ''
-  for c in b64:
-    if c == '+':
-      out += '-'
-    elif c == '/':
-      out += '_'
-    elif c == '=':
-      out += '.'
+class TMobileGatewayInterface:
+  def __init__(self, user_hash = None, random_key_hash = None, response = None, nonce = None, creds_filename = None):
+    if creds_filename:
+      self.load_credentials(creds_filename)
     else:
-      out += c
-  return out
+      self.user_hash = user_hash
+      self.random_key_hash = random_key_hash
+      self.response = response
+      self.nonce = nonce
+    self.jar = requests.cookies.RequestsCookieJar()
+    self.csrf_token = None
 
-def sha256(val1, val2):
-  hash = hashlib.sha256()
-  hash.update((val1 + ':' + val2).encode())
-  return b64encode(hash.digest()).decode('utf-8')
+  def fetch_credentials(self, username, password):
+    nonce_request = requests.get('http://192.168.12.1/login_web_app.cgi?nonce')
+    nonce_request.raise_for_status()
+    nonce_response = nonce_request.json()
+    
+    user_pass_sha = self.sha256(username, password)
+    self.user_hash = self.sha256url(username, nonce_response['nonce'])
+    self.random_key_hash = self.sha256url(nonce_response['randomKey'], nonce_response['nonce'])
+    self.response = self.sha256url(user_pass_sha, nonce_response['nonce'])
+    self.nonce = self.base64url_escape(nonce_response['nonce'])
+  
+  def save_credentials(self, filename):
+    creds_json = {
+      'user_hash': self.user_hash,
+      'random_key_hash': self.random_key_hash,
+      'response': self.response,
+      'nonce': self.nonce
+    }
+    with open(filename, 'w') as file:
+      json.dump(creds_json, file)
+    print('Credentials saved to ' + filename)
+  
+  def load_credentials(self, filename):
+    with open(filename, 'r') as file:
+      creds_json = json.load(file)
+    self.user_hash = creds_json['user_hash']
+    self.random_key_hash = creds_json['random_key_hash']
+    self.response = creds_json['response']
+    self.nonce = creds_json['nonce']
+    print('Credentials loaded from ' + filename)
 
-def sha256url(val1, val2):
-  return base64url_escape(sha256(val1, val2))
+  def login(self):
+    base_key = b64encode(secrets.token_bytes(16)).decode('utf-8')
+    base_iv = b64encode(secrets.token_bytes(16)).decode('utf-8')
+    login_request_body = {
+      'userhash': self.user_hash,
+      'RandomKeyhash': self.random_key_hash,
+      'response': self.response,
+      'nonce': self.nonce,
+      'enckey': self.base64url_escape(base_key),
+      'enciv': self.base64url_escape(base_iv)
+    }
+  
+    login_request = requests.post('http://192.168.12.1/login_web_app.cgi', data=login_request_body)
+    login_request.raise_for_status()
+    login_response = login_request.json()
+
+    self.jar.set('sid', login_request.cookies['sid'], domain='192.168.12.1', path='/')
+    self.jar.set('lsid', login_request.cookies['lsid'], domain='192.168.12.1', path='/')
+    self.csrf_token = login_response['token']
+
+  def reboot(self):
+    if not self.csrf_token:
+      self.logn()
+    reboot_request = requests.post('http://192.168.12.1/reboot_web_app.cgi', data={'csrf_token': self.csrf_token}, cookies=self.jar)
+    reboot_request.raise_for_status()
+  
+  def check_status(self, interface = None, ping_host = 'google.com'):
+    # returns True if status is OK, False if reboot needed
+    signal_request = requests.get('http://192.168.12.1/fastmile_radio_status_web_app.cgi')
+    signal_request.raise_for_status()
+    signal_info = signal_request.json()
+    band_5g = signal_info['cell_5G_stats_cfg'][0]['stat']['Band']
+    if band_5g != 'n41':
+      print('Not on n41. Reboot requested.')
+      return False
+    else:
+      print('Camping on n41.')
+      ping_cmd = ['ping']
+      if interface:
+        ping_cmd.append('-I')
+        ping_cmd.append(interface)
+      ping_cmd.append('-c')
+      ping_cmd.append('1')
+      ping_cmd.append(ping_host)
+      if subprocess.call(ping_cmd) != 0:
+        print('Could not ping ' + ping_host + '. Reboot requested.')
+        return False
+      else:
+        print('Successfully pinged ' + ping_host + '.')
+        return True
+
+  def base64url_escape(self, b64):
+    out = ''
+    for c in b64:
+      if c == '+':
+        out += '-'
+      elif c == '/':
+        out += '_'
+      elif c == '=':
+        out += '.'
+      else:
+        out += c
+    return out
+
+  def sha256(self, val1, val2):
+    hash = hashlib.sha256()
+    hash.update((val1 + ':' + val2).encode())
+    return b64encode(hash.digest()).decode('utf-8')
+
+  def sha256url(self, val1, val2):
+    return self.base64url_escape(self.sha256(val1, val2))
+
 
 parser = argparse.ArgumentParser(description='Check T-Mobile Home Internet 5g band and connectivity and reboot if necessary')
-parser.add_argument('username', type=str, help='the username. should be admin')
-parser.add_argument('password', type=str, help='the administrative password')
+parser.add_argument('-u', '--username', type=str, help='the administrative username (defaults to "admin")', default='admin')
+parser.add_argument('-p', '--password', type=str, help='the administrative password (will be prompted if not passed as argument)')
 parser.add_argument('-I', '--interface', type=str, help='the network interface to use for ping')
-parser.add_argument('-H', '--ping-host', type=str, default='google.com', help='the host to ping')
-parser.add_argument('-R', '--reboot', action="store_true", help='skip health checks and immediately reboot gateway')
+parser.add_argument('-H', '--ping-host', type=str, default='google.com', help='the host to ping (defaults to google.com)')
+parser.add_argument('-g', '--generate-credentials', action='store_true', help='generate credentials and exit (saved as credentials.json unless used in combination with -f)')
+parser.add_argument('-f', '--credentials-file', type=str, help='file from which to save/load saved credentials')
+parser.add_argument('-R', '--reboot', action='store_true', help='skip health checks and immediately reboot gateway')
 args = parser.parse_args()
+
+if args.credentials_file and not args.generate_credentials:
+  gateway = TMobileGatewayInterface(creds_filename = args.credentials_file)
+else:
+  if not args.password:
+    args.password = getpass.getpass()
+  gateway = TMobileGatewayInterface()
+  gateway.fetch_credentials(args.username, args.password)
+
+if args.generate_credentials:
+  args.credentials_file = args.credentials_file or 'credentials.json'
+  gateway.save_credentials(args.credentials_file)
+  exit()
 
 reboot_requested = args.reboot
 
 if not reboot_requested:
-  signal_request = requests.get('http://192.168.12.1/fastmile_radio_status_web_app.cgi')
-  signal_request.raise_for_status()
-  signal_info = signal_request.json()
-  band_5g = signal_info['cell_5G_stats_cfg'][0]['stat']['Band']
-  if band_5g != 'n41':
-    print('Not on n41. Reboot requested.')
-    reboot_requested = True
-  else:
-    print('Camping on n41. Not rebooting.')
-
-  ping_cmd = ['ping']
-  if args.interface:
-    ping_cmd.append('-I')
-    ping_cmd.append(args.interface)
-  ping_cmd.append('-c')
-  ping_cmd.append('1')
-  ping_cmd.append(args.ping_host)
-
-if not reboot_requested and subprocess.call(ping_cmd) != 0:
-  print('Could not ping ' + args.ping_host + '. reboot requested')
-  reboot_requested = True
+  reboot_requested = not gateway.check_status(args.interface, args.ping_host)
 
 if reboot_requested:
   print('Rebooting.')
-  reboot()
+  gateway.login()
+  gateway.reboot()
 else:
   print('No reboot necessary.')


### PR DESCRIPTION
An obnoxious number of changes, any of which you're free to veto or tell me to modify. The basic idea behind all of this was to make it possible to save the encrypted credentials to a file for later use so a user wouldn't need to either (a) store their router password as plaintext in a cronjob or, at the every least, their bash history or (b) always be prompted for a password. Note that I still need to test the longevity of the credentials, because if they expire after a few hours (or even a few days), then they're not nearly as useful for this idea, and I'll need to figure something else out (or settle for my unencrypted router password stored in crontab, sigh).

Anyways, the major changes are:
* Allow for credentials to be saved to and loaded from a JSON file
* Set a default for the admin username (to uh... `admin`)
* Allow the user to either pass the password in as an argument or input it at a password prompt
* Move everything into a class and instantiate that class (this really wasn't *entirely* necessary, I'm just a nerd)

If you want some of these changes but not all, feel free to copy+paste, or even ask me to go make a less-drastically-changed branch.