### PR TITLE
Support macOS ping output format

### DIFF
--- a/tmo-monitor.py
+++ b/tmo-monitor.py
@@ -17,6 +17,7 @@ import re
 import tailer
 from parse import *
 
+
 def print_and_log(msg, level='INFO'):
   print(msg)
   lvl = logging.getLevelName(level)
@@ -147,7 +148,7 @@ class TrashCanController:
         return -1
       if is_win and 'Destination host unreachable' in str(ping_exec.stdout):
         return -1
-      pattern = b'[rtt|round-trip] min/avg/max/mdev = \d+.\d+/(\d+.\d+)/\d+.\d+/\d+.\d+ ms'
+      pattern = b'[rtt|round-trip] min/avg/max/(?:mdev|stddev) = \d+.\d+/(\d+.\d+)/\d+.\d+/\d+.\d+ ms'
       if is_win:
         pattern = b'Minimum = \d+ms, Maximum = \d+ms, Average = (\d+)ms'
       ping_ms = re.search(pattern, ping_exec.stdout)

--- a/tmo-monitor.py
+++ b/tmo-monitor.py
@@ -17,7 +17,6 @@ import re
 import tailer
 from parse import *
 
-
 def print_and_log(msg, level='INFO'):
   print(msg)
   lvl = logging.getLevelName(level)


### PR DESCRIPTION
Fixes #35.

Updates the ping parsing regex to handle `stddev` (which macOS prints) in addition to `mdev`. 