### PR TITLE
Included Docker image generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/.git/
+*
+!/*.py
+!/requirements.txt
+!/docker/entrypoint.sh

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,31 @@
+name: docker
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        if: github.ref == 'refs/heads/master'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          tags: hugohh/tmo-monitor:latest
+          push: ${{ github.ref == 'refs/heads/master' }}

--- a/README.md
+++ b/README.md
@@ -159,3 +159,29 @@ Environment settings are meant to be declarative. They fall into four categories
 
 ## Tip
 Run this script with either a cronjob or as a systemd service to implement periodic recurring T-Mobile Home Internet health checks with automatic rebooting.
+
+## Dockerized version
+
+### Usage
+
+Start the docker container with:
+
+* Your env file mapped to `/.env`.
+* A crontab file mapped to `/crontab`.
+
+### Example
+
+Running the container as:
+
+```sh
+docker run -v /etc/localtime:/etc/localtime:ro -v $PWD/monitor.env:/.env:ro -v $PWD/monitor.crontab:/crontab:ro hugohh/tmo-monitor:latest
+```
+
+with the following crontab:
+
+```
+*/2 * * * * /tmo-monitor/tmo-monitor.py --skip-bands
+1 4 * * * /tmo-monitor/tmo-monitor.py --skip-ping
+```
+
+will run a ping test every 2 minutes and a band test every day at 4:01am.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:alpine
+
+LABEL org.opencontainers.image.source="https://github.com/highvolt-dev/tmo-monitor"
+
+RUN apk add iputils git
+
+RUN adduser -D -h /monitor monitor
+
+COPY docker/entrypoint.sh /
+
+COPY . /tmo-monitor
+RUN cd tmo-monitor && \
+    pip3 install -r requirements.txt
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,13 @@ FROM python:alpine
 
 LABEL org.opencontainers.image.source="https://github.com/highvolt-dev/tmo-monitor"
 
-RUN apk add iputils git
+RUN apk add iputils
 
 RUN adduser -D -h /monitor monitor
 
-COPY docker/entrypoint.sh /
-
 COPY . /tmo-monitor
+
 RUN cd tmo-monitor && \
     pip3 install -r requirements.txt
 
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "/tmo-monitor/docker/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+crontab -u monitor /crontab
+crond -f


### PR DESCRIPTION
Here's a proposed patch to solve #42.

To make it work: do a search and replace of hugohh/tmo-monitor into your know Docker Hub username/repo, and add the corresponding DOCKERHUB_USERNAME and DOCKERHUB_TOKEN as repository secrets.