### PR TITLE
Support for Busybox's ping

### DIFF
--- a/tmo-monitor.py
+++ b/tmo-monitor.py
@@ -147,7 +147,7 @@ class TrashCanController:
         return -1
       if is_win and 'Destination host unreachable' in str(ping_exec.stdout):
         return -1
-      pattern = b'(?:rtt|round-trip) min/avg/max/(?:mdev|stddev) = \d+.\d+/(\d+.\d+)/\d+.\d+/\d+.\d+ ms'
+      pattern = b'(?:rtt|round-trip) min/avg/max(?:/(?:mdev|stddev))? = \d+.\d+/(\d+.\d+)/\d+.\d+(?:/\d+.\d+)? ms'
       if is_win:
         pattern = b'Minimum = \d+ms, Maximum = \d+ms, Average = (\d+)ms'
       ping_ms = re.search(pattern, ping_exec.stdout)


### PR DESCRIPTION
Busybox's ping doesn't show standard deviation:

```
/ # ping localhost
PING localhost (127.0.0.1): 56 data bytes
64 bytes from 127.0.0.1: seq=0 ttl=64 time=1.398 ms
64 bytes from 127.0.0.1: seq=1 ttl=64 time=0.204 ms
^C
--- localhost ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0.204/0.801/1.398 ms
```

This patch updates the regular expression to handle it.