### PR TITLE
Fixed tmo_monitor.gateway module installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ setup(
   url='https://github.com/highvolt-dev/tmo-monitor',
   author='highvolt-dev',
   license='MIT',
-  packages=['tmo_monitor'],
+  packages=[
+    'tmo_monitor',
+    'tmo_monitor.gateway'
+  ],
   scripts=['bin/tmo-monitor.py'],
   install_requires=[
     'parse',


### PR DESCRIPTION
Fixed the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/tmo-monitor.py", line 6, in <module>
    from tmo_monitor.gateway.model import GatewayModel
ModuleNotFoundError: No module named 'tmo_monitor.gateway'
```
